### PR TITLE
Add metadata for `specification` to be required as data-only python package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,7 @@
+graft attribution
+graft bin
+graft collection
+graft content
+graft docs
+graft specification
+graft templates

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,40 @@
+import os
+
+from setuptools import setup
+
+
+def get_long_description():
+    with open(
+        os.path.join(os.path.dirname(os.path.abspath(__file__)), "README.md"),
+        encoding="utf8",
+    ) as fp:
+        return fp.read()
+
+
+setup(
+    name="specification",
+    version="0.0.1",
+    description="Digital Land specifications, built upon the GOV.UK Registers data model.",
+    long_description=get_long_description(),
+    long_description_content_type="text/markdown",
+    author="MHCLG Digital Land Team",
+    author_email="DigitalLand@communities.gov.uk",
+    license="MIT",
+    url="https://github.com/digital-land/specification",
+    packages=["specification"],
+    package_data={
+        "digital_land/specification": ["specification/*"],
+        "specification": ["specification/*"],
+    },
+    include_package_data=True,
+    install_requires=[
+    ],
+    classifiers=[
+        "Development Status :: 3 - Alpha",
+        "Intended Audience :: Developers",
+        "Topic :: Database",
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+    ],
+)

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,8 @@ import os
 
 from setuptools import setup
 
+from version import get_version
+
 
 def get_long_description():
     with open(
@@ -13,7 +15,7 @@ def get_long_description():
 
 setup(
     name="specification",
-    version="0.0.1",
+    version=get_version(),
     description="Digital Land specifications, built upon the GOV.UK Registers data model.",
     long_description=get_long_description(),
     long_description_content_type="text/markdown",

--- a/version.py
+++ b/version.py
@@ -9,10 +9,10 @@ import subprocess
 def get_version():
     try:
         return (
-            subprocess.check_output(["git", "rev-parse", "HEAD"])[:-1].decode("utf-8")
+            subprocess.check_output(["git", "show", "-s", "--format=%h"])[:-1].decode("utf-8")
         )
     except subprocess.CalledProcessError:
-        print("Unable to get current commit hash from git rev-parse")
+        print("Unable to get current commit hash from git show")
         sys.exit(1)
 
 

--- a/version.py
+++ b/version.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+"""
+Use `git` executable on PATH to print current commit hash of working directory
+"""
+import sys
+import subprocess
+
+
+def get_version():
+    try:
+        return (
+            subprocess.check_output(["git", "rev-parse", "HEAD"])[:-1].decode("utf-8")
+        )
+    except subprocess.CalledProcessError:
+        print("Unable to get current commit hash from git rev-parse")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    print(get_version())


### PR DESCRIPTION
* Add metadata for `specification` to be required as data-only python package