### PR TITLE
Added missing dataset markdown for dataset registers we are managing …

### DIFF
--- a/content/dataset/development-plan-event.md
+++ b/content/dataset/development-plan-event.md
@@ -1,0 +1,35 @@
+---
+attribution: crown-copyright
+collection: ''
+dataset: development-plan-event
+description: The different event types in a development plan timetable
+end-date: ''
+entity-maximum: '2999999'
+entity-minimum: '2900000'
+entry-date: '2023-09-14'
+fields:
+- field: end-date
+- field: entity
+- field: entry-date
+- field: name
+- field: notes
+- field: description
+- field: prefix
+- field: reference
+- field: start-date
+key-field: ''
+licence: ogl3
+name: Development plan event
+paint-options: ''
+phase: alpha
+plural: Development plan events
+prefix: ''
+realm: dataset
+start-date: ''
+themes:
+- development
+typology: category
+version: 1.0
+wikidata: ''
+wikipedia: ''
+---

--- a/content/dataset/planning-application-category.md
+++ b/content/dataset/planning-application-category.md
@@ -1,0 +1,35 @@
+---
+attribution: crown-copyright
+collection:
+dataset: planning-application-category
+description: ''
+end-date: ''
+entity-maximum: '3999999'
+entity-minimum: '3900000'
+entry-date: '2023-09-14'
+fields:
+- field: end-date
+- field: entity
+- field: entry-date
+- field: name
+- field: notes
+- field: description
+- field: prefix
+- field: reference
+- field: start-date
+licence: ogl3
+name: Planning application category
+paint-options: ''
+phase: discovery
+plural: Planning application categories
+prefix: ''
+realm: dataset
+start-date: ''
+themes:
+- housing
+- monitoring
+typology: category
+version: 1.0
+wikidata: ''
+wikipedia: ''
+---

--- a/content/dataset/planning-application-category.md
+++ b/content/dataset/planning-application-category.md
@@ -2,7 +2,7 @@
 attribution: crown-copyright
 collection:
 dataset: planning-application-category
-description: ''
+description: 'A planning application category is a high level categorisation of the type of planning application, such as "householder" or "full planning application"'
 end-date: ''
 entity-maximum: '3999999'
 entity-minimum: '3900000'


### PR DESCRIPTION
…in dataset editor.

@mattlucht and @colmjude  you both ok with these? They are datasets for which we have csv files being managed in dluhc dataset editor but with no corresponding markdown in specification repo.