### PR TITLE
remove value field from lookup

### DIFF
--- a/content/dataset/lookup.md
+++ b/content/dataset/lookup.md
@@ -17,7 +17,6 @@ fields:
 - field: prefix
 - field: resource
 - field: start-date
-- field: value
 - field: reference
 key-field: ''
 licence: ogl3

--- a/content/dataset/lookup.md
+++ b/content/dataset/lookup.md
@@ -31,7 +31,7 @@ themes:
 - specification
 - pipeline
 typology: specification
-version: 1.0
+version: 2.0
 wikidata: ''
 wikipedia: ''
 ---


### PR DESCRIPTION
`value` was replaced by `reference` in config files so is no longer needed in the spec.