### PR TITLE
Add task schema to specification

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,42 @@
+name: Test
+run-name: Test - ${{ github.head_ref || github.ref_name }} by @${{ github.actor }}
+
+on:
+  push:
+    paths-ignore:
+      - 'collection/resource/**'
+      - 'collection/log/**'
+      - 'index/**'
+      - 'var/**'
+    branches-ignore: [main]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+
+    - name: Branch name
+      run: echo running on branch ${GITHUB_REF##*/}
+
+    - name: Update makerules
+      run: make makerules
+
+    - name: Clean specification and docs
+      run: make clean clobber
+
+    - name: Install dependencies
+      run: make init
+
+    - name: Build specification
+      run: make specification
+
+    - name: Check specification
+      run: make check
+
+    - name: Build docs
+      run: make render

--- a/content/dataset/task.md
+++ b/content/dataset/task.md
@@ -3,7 +3,7 @@ attribution: crown-copyright
 collection: ''
 consideration: ''
 dataset: task
-description: An amalgamation of 
+description: Tasks are an amalgamation of the various data quality checks that are run in the pipeline that need to be fixed (e.g. issues, expectations, collection logs).
 end-date: ''
 entry-date: ''
 fields:

--- a/content/dataset/task.md
+++ b/content/dataset/task.md
@@ -1,0 +1,35 @@
+---
+attribution: crown-copyright
+collection: ''
+consideration: ''
+dataset: task
+description: An amalgamation of 
+end-date: ''
+entry-date: ''
+fields:
+- field: dataset
+- field: organisation
+- field: endpoint
+- field: resource
+- field: details
+- field: severity
+- field: responsibility
+- field: task-source
+- field: end-date
+- field: entry-date
+- field: start-date
+licence: ogl3
+name: Task
+paint-options: ''
+phase: alpha
+plural: Tasks
+prefix: ''
+realm: configuration
+replacement-dataset: ''
+start-date: ''
+themes:
+- pipeline
+typology: pipeline
+wikidata: ''
+wikipedia: ''
+---

--- a/content/dataset/task.md
+++ b/content/dataset/task.md
@@ -24,7 +24,7 @@ paint-options: ''
 phase: alpha
 plural: Tasks
 prefix: ''
-realm: configuration
+realm: provenance
 replacement-dataset: ''
 start-date: ''
 themes:

--- a/content/field/task-source.md
+++ b/content/field/task-source.md
@@ -1,0 +1,17 @@
+---
+cardinality: '1'
+datatype: string
+description: ''
+end-date: ''
+entry-date: ''
+field: task-source
+guidance: ''
+hint: ''
+name: Task Source
+parent-field: specification
+replacement-field: ''
+start-date: ''
+typology: specification
+uri-template: ''
+wikidata-property: ''
+---

--- a/content/field/task-source.md
+++ b/content/field/task-source.md
@@ -1,7 +1,7 @@
 ---
 cardinality: '1'
 datatype: string
-description: ''
+description: 'the source dataset of the task, the dataset should be in the provenance realm'
 end-date: ''
 entry-date: ''
 field: task-source


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Adds the task dataset to the specification with the agreed fields from the Darlington Design Day. Also, creates `task-source` field as that is not currently an available field and will be needed for this work.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
- Ticket Link: https://github.com/digital-land/async-request-backend/issues/104

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [ ] Yes
- [X] No, and this is why: No tests on spec
- [ ] I need help with writing tests
