### PR TITLE
add check for dataset with  availablility but missing collection

### DIFF
--- a/bin/check.py
+++ b/bin/check.py
@@ -202,6 +202,11 @@ def check_availability():
                 "dataset '%s' has an unknown availability '%s'"
                 % (dataset, availability)
             )
+        if availability and not d.get("collection", ""):
+            error(
+                "dataset '%s' has availability '%s' but no collection — it will not appear in any Airflow environment"
+                % (dataset, availability)
+            )
 
 
 def check_projects():


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Adding a check for datasets which might get added with `availability` set but with an empty `collection` field.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
- Ticket Link
- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [ ] Yes
- [x] No, and this is why: not what we do in this repo.
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] Are there any dependencies on other PRs or Work?
