### PR TITLE
Update Slack alert to only run on main

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -112,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build
-    if: always() && needs.build.result == 'failure'
+    if: always() && needs.build.result == 'failure' && github.ref == 'refs/heads/main'
     steps:
       - name: send failure notification
         uses: slackapi/slack-github-action@v3.0.3


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [X] Optimization
- [ ] Documentation Update

## Description

Small PR to update the Slack alert on `run.yml` so it will only send a message to Slack if:
- There's a failure on the main branch