### PR TITLE
fix: size diagram canvas from the laid out columns

### DIFF
--- a/bin/specification-svg.py
+++ b/bin/specification-svg.py
@@ -109,13 +109,14 @@ def generate(specification_path, output_path=None):
 
     datasets = [d["dataset"] for d in row["datasets"]]
     maxrows = max([len(d["fields"]) for d in row["datasets"]])
-    ndatasets = len(datasets)
-    ngaps = ndatasets - 1
-    canvas_width = ndatasets * row_width + ngaps * gap
     canvas_height = (maxrows + 1) * row_height
 
     X = 0
     Y_OFFSET = 0
+    # a dataset that links back more than one column is wrapped onto a new row below, so the
+    # canvas is only as wide as the columns actually used, not as wide as the dataset count
+    # implies. Tracked as the boxes are placed and used as the canvas width once laid out.
+    content_width = 0
     points = {}
     links = []
     boxes = []
@@ -139,7 +140,9 @@ def generate(specification_path, output_path=None):
                 Y = Y + Y_OFFSET
                 X = X -row_width - gap
                 canvas_height = canvas_height + (maxrows + 1) * row_height
-                
+
+        content_width = max(content_width, X + row_width)
+
         box = []
         box.append(svg_rect("name", X, Y, row_width, row_height))
         box.append(svg_text("name", dataset, X + int(row_width / 2), Y + text_y))
@@ -167,6 +170,7 @@ def generate(specification_path, output_path=None):
         Y_OFFSET = Y + gap
 
     canvas_height += gap
+    canvas_width = content_width
 
     svg_content.append(
         f'<svg xmlns="http://www.w3.org/2000/svg" width="{canvas_width}" height="{canvas_height}">'

--- a/docs/specification/design-code/diagram.svg
+++ b/docs/specification/design-code/diagram.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="838" height="560">
+<svg xmlns="http://www.w3.org/2000/svg" width="532" height="560">
 <defs>
     <style>
     text{font-family:sans-serif; font-size:10px; dominant-baseline:middle;}

--- a/docs/specification/infrastructure-project/diagram.svg
+++ b/docs/specification/infrastructure-project/diagram.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="838" height="760">
+<svg xmlns="http://www.w3.org/2000/svg" width="532" height="760">
 <defs>
     <style>
     text{font-family:sans-serif; font-size:10px; dominant-baseline:middle;}

--- a/docs/specification/planning-application-decision/diagram.svg
+++ b/docs/specification/planning-application-decision/diagram.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="838" height="800">
+<svg xmlns="http://www.w3.org/2000/svg" width="532" height="800">
 <defs>
     <style>
     text{font-family:sans-serif; font-size:10px; dominant-baseline:middle;}

--- a/docs/specification/tree-preservation-order/diagram.svg
+++ b/docs/specification/tree-preservation-order/diagram.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="838" height="640">
+<svg xmlns="http://www.w3.org/2000/svg" width="532" height="640">
 <defs>
     <style>
     text{font-family:sans-serif; font-size:10px; dominant-baseline:middle;}


### PR DESCRIPTION
## Description

`canvas_width` was calculated from the dataset count before the layout ran, so a specification whose dataset links back more than one column got a canvas wide enough for every dataset side by side, even though the layout wraps that dataset onto a new row below instead.

`tree-preservation-order` declared 838 wide while its content stopped at 532, so a third of the canvas was empty. Anywhere the diagram is shown with `max-width: 100%` that dead space forces it to scale down further than it needs to, making the text smaller than it should be.

The fix tracks the rightmost edge as the boxes are placed and uses that as the canvas width.

## What changes

Four diagrams, and only their `<svg>` tag:

| diagram | before | after |
| --- | --- | --- |
| tree-preservation-order | 838x640 | 532x640 |
| design-code | 838x560 | 532x560 |
| infrastructure-project | 838x760 | 532x760 |
| planning-application-decision | 838x800 | 532x800 |

The other 15 diagrams regenerate byte for byte identical.

## Testing

Regenerated every diagram and confirmed the content fits the new canvas in all four cases (max content x is exactly 532 in each, nothing clipped), and that no other diagram changed. Rendered `tree-preservation-order` before and after in a 605px column: it now draws at its natural 532x640 rather than being scaled down to 605x462.
